### PR TITLE
Fix error when no pixel ID is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix error when no pixel ID is defined.
 
 ## [0.1.0] - 2018-10-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.1] - 2018-10-18
 ### Fixed
 - Fix error when no pixel ID is defined.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "facebook-pixel",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "title": "Facebook Pixel",
   "description": "Facebook Pixel",
   "defaultLocale": "pt-BR",

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -47,6 +47,14 @@ class FacebookPixel extends Component<Props> {
     this.unsubscribe = props.subscribe(this)
   }
 
+  public track = (eventName: string, data: any) => {
+    if (!fbq) {
+      return
+    }
+
+    fbq('track', eventName, data)
+  }
+
   public shouldComponentUpdate() {
     // the component should only be rendered once
     return false
@@ -79,7 +87,7 @@ class FacebookPixel extends Component<Props> {
 
   public trackCategoryPage(page: string) {
     return (data: any) => {
-      fbq('track', 'ViewContent', {
+      this.track('ViewContent', {
         ...formatSearchResultProducts(data.products),
         content_category: page,
         content_type: 'product_group',
@@ -95,13 +103,13 @@ class FacebookPixel extends Component<Props> {
   /* tslint:enable member-ordering */
 
   public internalSiteSearchView = (data: any) => {
-    fbq('track', 'Search', formatSearchResultProducts(data.products))
+    this.track('Search', formatSearchResultProducts(data.products))
   }
 
   public productView = (data: any) => {
     const { product: { productName, productId } } = data
 
-    fbq('track', 'ViewContent', {
+    this.track('ViewContent', {
       content_category: 'product',
       content_ids: [productId],
       content_name: name,

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -48,7 +48,7 @@ class FacebookPixel extends Component<Props> {
   }
 
   public track = (eventName: string, data: any) => {
-    if (!fbq) {
+    if (typeof fbq === 'undefined') {
       return
     }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a check before calling the `fbq` tracker.

#### What problem is this solving?
When no pixel ID is set on the admin, the component will mount and will continue to receive the events from the pixel, but the `fbq` function won't be available and will throw an error when called.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/samsung-s9-x/p), remove the pixel ID from the admin and access again.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
