### PR TITLE
Fix content_ids field on search pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.2] - 2018-10-19
 ### Fixed
 - Fix `content_ids` field in search, department and category pages.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix `content_ids` field in search, department and category pages.
 
 ## [1.0.1] - 2018-10-19
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "facebook-pixel",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "title": "Facebook Pixel",
   "description": "Facebook Pixel",
   "defaultLocale": "pt-BR",

--- a/react/utils/formatHelper.ts
+++ b/react/utils/formatHelper.ts
@@ -6,7 +6,7 @@ export function getProductPrice(product: any) {
 
 export function formatSearchResultProducts(products: any[]) {
   return {
-    content_ids: products.map(product => product.id),
+    content_ids: products.map(product => product.productId),
     contents: products.map(product => {
       const quantity = product.items.reduce((acc: number, sku: any) => {
         const sellersQuantity = sku.sellers.reduce((sellerAcc: number, seller: any) => (


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix wrong property being used for the product id.

#### What problem is this solving?
The `content_ids` field was an array of `null`.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/eletronicos/d).

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
