### PR TITLE
Track all skus in ViewContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Track all skus of in ViewContent event.
 
 ## [2.0.1] - 2019-06-07
 

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -26,10 +26,10 @@ function handleMessages(e: PixelMessage) {
       break
     }
     case 'vtex:productView': {
-      const { product: { productId, productName }, currency } = e.data
+      const { product: { productName, items }, currency } = e.data
 
       fbq('track', 'ViewContent', {
-        content_ids: [productId],
+        content_ids: items.map(({ itemId }) => itemId),
         content_name: productName,
         content_type: 'product',
         currency,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Change tracking ViewContent to track all skus instead of product.

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/classic-shoes/p

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
