### PR TITLE
Add agent to track VTEX and GoCommerce pixels.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## Changed
-- Add agent so Facebook can track VTEX/GoCommerce pixels.
+## Added
+- Agent field, so Facebook can track VTEX/GoCommerce pixels.
 
 ## [2.0.4] - 2019-10-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+- Add agent so Facebook can track VTEX/GoCommerce pixels.
 
 ## [2.0.4] - 2019-10-14
 

--- a/pixel/body.html
+++ b/pixel/body.html
@@ -12,8 +12,8 @@
       t.src=v;s=b.getElementsByTagName(e)[0];
       s.parentNode.insertBefore(t,s)}(window, document,'script',
       'https://connect.facebook.net/en_US/fbevents.js');
-      var plat = window.__RUNTIME__.platform == 'vtex' ? 'plvtex': 'plgocommerce';
-      fbq('init',pixelId,{},{'agent':plat});
+      var platform = window.__RUNTIME__.platform == 'vtex' ? 'plvtex': 'plgocommerce';
+      fbq('init', pixelId, {}, {"agent": platform});
     }
   })()
 </script>

--- a/pixel/body.html
+++ b/pixel/body.html
@@ -12,7 +12,8 @@
       t.src=v;s=b.getElementsByTagName(e)[0];
       s.parentNode.insertBefore(t,s)}(window, document,'script',
       'https://connect.facebook.net/en_US/fbevents.js');
-      fbq('init', pixelId);
+      var plat = window.__RUNTIME__.platform == 'vtex' ? 'plvtex': 'plgocommerce';
+      fbq('init',pixelId,{},{'agent':plat});
     }
   })()
 </script>

--- a/react/package.json
+++ b/react/package.json
@@ -15,6 +15,6 @@
     "tslint": "^5.11.0",
     "tslint-config-vtex": "^2.0.0",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "^3.1.1"
+    "typescript": "3.7.3"
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -358,10 +358,10 @@ tsutils@^3.0.0:
   dependencies:
     tslib "^1.8.1"
 
-typescript@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.1.tgz#3362ba9dd1e482ebb2355b02dfe8bcd19a2c7c96"
-  integrity sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==
+typescript@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says
<!--- Describe your changes in detail. -->

#### What problem is this solving?
Now Facebook can track how many pixels VTEX and GoCommerce have.
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
https://facebook--storecomponents.myvtex.com/
(Actually only Facebook will be able to see this change)

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
