### PR TITLE
feat: Add multiple bindings configs permission in pixel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Add permission to config multiple bindings
+
 ### Fixed
 - New terms of use
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Added
 - Add permission to config multiple bindings
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -29,6 +29,7 @@
   "settingsSchema": {
     "title": "Facebook Pixel",
     "type": "object",
+    "bindingBounded": true,
     "properties": {
       "pixelId": {
         "title": "Facebook Pixel ID",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add permission to use multiple bindings inside facebook pixel app

#### What problem is this solving?

Use different settings in different bindings

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
