### PR TITLE
Vary product details page event content_type if product has more than one SKU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Vary product details page event `content_type` if product has more than one SKU.
+
 ## [2.2.1] - 2020-10-27
 ### Fixed
 - Currency values in AddToCart event.

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -25,12 +25,26 @@ function handleMessages(e: PixelMessage) {
       break
     }
     case 'vtex:productView': {
-      const { product: { productName, items }, currency } = e.data
+      const { product: { productName, productId, items }, currency } = e.data
+
+      // The event varies if the product has SKUs, see:
+      // https://developers.facebook.com/docs/marketing-api/audiences/guides/dynamic-product-audiences#
+      const noVariants = items.length === 1
+      if (noVariants) {
+        fbq('track', 'ViewContent', {
+          content_ids: [items[0].itemId],
+          content_name: productName,
+          content_type: 'product',
+          currency,
+          value: getProductPrice(e.data.product),
+        })
+        return
+      }
 
       fbq('track', 'ViewContent', {
-        content_ids: items.map(({ itemId }) => itemId),
+        content_ids: [productId],
         content_name: productName,
-        content_type: 'product',
+        content_type: 'product_group',
         currency,
         value: getProductPrice(e.data.product),
       })

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -1,11 +1,88 @@
 export interface PixelMessage extends MessageEvent {
-  data: ProductViewData | ProductClickData | OrderPlacedData | PageViewData | ProductImpressionData | AddToCartData | RemoveToCartData | CategoryViewData | DepartmentViewData
+  data:
+    | ProductViewData
+    | ProductClickData
+    | OrderPlacedData
+    | OrderPlacedTrackedData
+    | PageViewData
+    | ProductImpressionData
+    | AddToCartData
+    | RemoveToCartData
+    | CartChangedData
+    | HomePageInfo
+    | ProductPageInfoData
+    | SearchPageInfoData
+    | UserData
+    | CartIdData
+    | PromoViewData
+    | PromotionClickData
 }
 
 export interface EventData {
   event: string
   eventName: string
   currency: string
+}
+
+export interface PageInfoData extends EventData {
+  event: 'pageInfo'
+  eventName: 'vtex:pageInfo'
+  accountName: string
+  pageTitle: string
+  pageUrl: string
+}
+
+export interface UserData extends PageInfoData {
+  eventType: 'userData'
+  eventName: 'vtex:userData'
+  firstName?: string
+  lastName?: string
+  document?: string
+  id?: string
+  email?: string
+  phone?: string
+  isAuthenticated: boolean
+}
+
+export interface CartIdData extends PageInfoData {
+  eventType: 'cartId'
+  eventName: 'vtex:cartId'
+  cartId: string
+}
+
+export interface HomePageInfo extends PageInfoData {
+  eventType: 'homeView'
+}
+
+export interface ProductPageInfoData extends PageInfoData {
+  eventType: 'productPageInfo'
+}
+
+export interface SearchPageInfoData extends PageInfoData {
+  eventType:
+    | 'internalSiteSearchView'
+    | 'categoryView'
+    | 'departmentView'
+    | 'emptySearchView'
+  category?: CategoryMetaData
+  department?: DepartmentMetaData
+  search?: SearchMetaData
+}
+
+interface CategoryMetaData {
+  id: string
+  name: string
+}
+
+interface DepartmentMetaData {
+  id: string
+  name: string
+}
+
+interface SearchMetaData {
+  term: string
+  category: CategoryMetaData
+  results: number
 }
 
 export interface PageViewData extends EventData {
@@ -16,33 +93,32 @@ export interface PageViewData extends EventData {
   referrer: string
 }
 
-export interface CategoryViewData extends EventData {
-  event: 'categoryView'
-  eventName: 'vtex:categoryView'
-  products: Product[]
-}
-
-export interface DepartmentViewData extends EventData {
-  event: 'departmentView'
-  eventName: 'vtex:departmentView'
-  products: Product[]
-}
-
 export interface AddToCartData extends EventData {
   event: 'addToCart'
   eventName: 'vtex:addToCart'
-  items: AddToCartProduct[]
+  items: CartItem[]
 }
 
 export interface RemoveToCartData extends EventData {
   event: 'removeFromCart'
   eventName: 'vtex:removeFromCart'
-  items: any[]
+  items: CartItem[]
+}
+
+export interface CartChangedData extends EventData {
+  event: 'cartChanged'
+  eventName: 'vtex:cartChanged'
+  items: CartItem[]
 }
 
 export interface OrderPlacedData extends Order, EventData {
   event: 'orderPlaced'
   eventName: 'vtex:orderPlaced'
+}
+
+export interface OrderPlacedTrackedData extends Order, EventData {
+  event: 'orderPlacedTracked'
+  eventName: 'vtex:orderPlacedTracked'
 }
 
 export interface ProductViewData extends EventData {
@@ -54,111 +130,207 @@ export interface ProductViewData extends EventData {
 export interface ProductClickData extends EventData {
   event: 'productClick'
   eventName: 'vtex:productClick'
-  product: Product
+  product: ProductSummary
 }
 
 export interface ProductImpressionData extends EventData {
   event: 'productImpression'
   eventName: 'vtex:productImpression'
-  product: Product
-  position: number
+  impressions: Impression[]
+  product?: ProductSummary // deprecated, use impressions list!
+  position?: number // deprecated, use impressions list!
   list: string
 }
 
+export interface CartData extends EventData {
+  event: 'cart'
+  eventName: 'vtex:cart'
+  orderForm: OrderForm
+}
+
+export interface PromoViewData extends EventData {
+  event: 'promoView'
+  eventName: 'vtex:promoView'
+  promotions: Promotion[]
+}
+
+export interface PromotionClickData extends EventData {
+  event: 'promotionClick'
+  eventName: 'vtex:promotionClick'
+  promotions: Promotion[]
+}
+
+interface Promotion {
+  id?: string
+  name?: string
+  creative?: string
+  position?: string
+}
+
+interface CartItem {
+  brand: string
+  ean: string
+  category: string
+  detailUrl: string
+  imageUrl: string
+  name: string
+  price: number
+  productId: string
+  productRefId: string
+  quantity: number
+  seller: string
+  sellerName: string
+  skuId: string
+  variant: string
+}
+
+export interface OrderForm {
+  id: string
+  items: CartItem[]
+}
+
 export interface Order {
-  currency: string
   accountName: string
+  corporateName: string
+  coupon: string
+  currency: string
+  openTextField: string
   orderGroup: string
   salesChannel: string
-  coupon: string
-  visitorType: string
+  visitorAddressCity: string
+  visitorAddressComplement: string
+  visitorAddressCountry: string
+  visitorAddressNeighborhood: string
+  visitorAddressNumber: string
+  visitorAddressPostalCode: string
+  visitorAddressState: string
+  visitorAddressStreet: string
   visitorContactInfo: string[]
+  visitorContactPhone: string
+  visitorType: string
   transactionId: string
   transactionDate: string
   transactionAffiliation: string
-  transactionTotal: number,
-  transactionShipping: number,
-  transactionTax: number,
-  transactionCurrency: string,
-  transactionPaymentType: PaymentType[],
+  transactionTotal: number
+  transactionShipping: number
+  transactionSubtotal: number
+  transactionDiscounts: number
+  transactionTax: number
+  transactionCurrency: string
+  transactionPaymentType: PaymentType[]
   transactionShippingMethod: ShippingMethod[]
+  transactionLatestShippingEstimate: Date
   transactionProducts: ProductOrder[]
   transactionPayment: {
     id: string
   }
 }
 
-interface PaymentType {
+export interface Impression {
+  product: ProductSummary
+  position: number
+}
+
+export interface PaymentType {
   group: string
   paymentSystemName: string
   installments: number
   value: number
 }
 
-interface ShippingMethod {
+export interface ShippingMethod {
   itemId: string
   selectedSla: string
 }
 
-interface ProductOrder {
-  id: string,
-  name: string,
-  sku: string,
-  skuRefId: string,
-  skuName: string,
-  brand: string,
-  brandId: string,
-  seller: string,
-  sellerId: string,
-  category: string,
-  categoryId: string,
+export interface ProductOrder {
+  id: string
+  name: string
+  sku: string
+  skuRefId: string
+  skuName: string
+  productRefId: string
+  ean: string
+  slug: string
+  brand: string
+  brandId: string
+  seller: string
+  sellerId: string
+  category: string
+  categoryId: string
   categoryTree: string[]
   categoryIdTree: string[]
+  priceTags: PriceTag[]
   originalPrice: number
   price: number
   sellingPrice: number
   tax: number
   quantity: number
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   components: any[]
   measurementUnit: string
   unitMultiplier: number
 }
 
+export interface PriceTag {
+  identifier: string
+  isPercentual: boolean
+  value: number
+}
+
 export interface Product {
   brand: string
-  categoryId?: string // inconsistency
+  brandId: string
   categories: string[]
+  categoryId: string
+  categoryTree: Array<{ id: string; name: string }>
+  detailUrl: string
+  items: Item[]
+  linkText: string
   productId: string
   productName: string
-  selectedSku?: string // inconsistency
-  items: Item[]
-  sku: Item
-  [key: string]: any
+  productReference: string
+  selectedSku: Item
 }
 
-interface Item {
+export interface Item {
   itemId: string
   name: string
-  seller?: Seller
-  [key: string]: any
+  ean: string
+  referenceId: { Key: string; Value: string }
+  imageUrl: string
+  sellers: Seller[]
 }
 
-interface Seller {
-  commertialOffer: CommertialOffer
-  AvailableQuantity: number
-  [key: string]: any
-}
-
-interface CommertialOffer {
-  Price: number
-  [key: string]: any
-}
-
-interface AddToCartProduct {
+export interface ProductSummary {
   brand: string
+  brandId: string
+  categories: string[]
+  items: ItemSummary[]
+  linkText: string
+  productId: string
+  productName: string
+  productReference: string
+  sku: ItemSummary
+}
+
+interface ItemSummary {
+  itemId: string
+  ean: string
   name: string
-  price: number
-  quantity: number
-  skuId: string
-  variant: string
+  referenceId: { Key: string; Value: string }
+  seller: Seller
+  sellers: Seller[]
+}
+
+export interface Seller {
+  commertialOffer: CommertialOffer
+  sellerId: string
+  sellerName: string
+}
+
+export interface CommertialOffer {
+  Price: number
+  ListPrice: number
+  AvailableQuantity: number
 }


### PR DESCRIPTION

Reference: https://developers.facebook.com/docs/marketing-api/audiences/guides/dynamic-product-audiences#

#### What problem is this solving?

Send the right info to the event.

#### How should this be manually tested?

https://fbpixel--storecomponents.myvtex.com/

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
