### PR TITLE
Send orderGroup to on eventID field to deduplicate orders

### DIFF
--- a/react/index.tsx
+++ b/react/index.tsx
@@ -8,13 +8,13 @@ function handleMessages(e: PixelMessage) {
       break
     }
     case 'vtex:orderPlaced': {
-      const { currency, transactionTotal, transactionProducts, transactionId } = e.data
+      const { currency, transactionTotal, transactionProducts, orderGroup } = e.data
 
       fbq('track', 'Purchase', {
         value: transactionTotal,
         currency,
         content_type: 'product',
-        eventID: transactionId,
+        eventID: orderGroup,
         contents: transactionProducts.map(
           (product: ProductOrder) => ({
             id: product.sku,

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -8,12 +8,13 @@ function handleMessages(e: PixelMessage) {
       break
     }
     case 'vtex:orderPlaced': {
-      const { currency, transactionTotal, transactionProducts } = e.data
+      const { currency, transactionTotal, transactionProducts, transactionId } = e.data
 
       fbq('track', 'Purchase', {
         value: transactionTotal,
         currency,
         content_type: 'product',
+        eventID: transactionId,
         contents: transactionProducts.map(
           (product: ProductOrder) => ({
             id: product.sku,


### PR DESCRIPTION
#### What is the purpose of this pull request?
This pull request includes a single change to the `handleMessages` function in `react/index.tsx` to enhance the tracking of purchase events by including an additional `eventID` field.

**Enhancement to purchase tracking:**

* [`react/index.tsx`](diffhunk://#diff-174bcc73617af1d55dc451e25955885251e14294d7b51467176108c27c279bb1L11-R17): Updated the `handleMessages` function to extract the `orderGroup` field from the event data and include it as the `eventID` in the `fbq('track', 'Purchase')` call.
#### What problem is this solving?
Duplication of 'Purchase' events

#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
